### PR TITLE
Replace os.rename with shutil.move in config_backup.py

### DIFF
--- a/configmaster/management/handlers/config_backup.py
+++ b/configmaster/management/handlers/config_backup.py
@@ -205,7 +205,7 @@ class NetworkDeviceConfigBackupHandler(NetworkDeviceHandler):
         try:
             if os.path.exists(filename):
                 os.unlink(filename)
-            os.rename(temp_filename, filename)
+            shutil.move(temp_filename, filename)
         finally:
             shutil.rmtree(temp_dir)
 


### PR DESCRIPTION
If source and destination are not on the same file system os.rename
results in `OSError: [Errno 18] Invalid cross-device link`.