### PR TITLE
Fix bug where FortiGate backups could be skipped in some cases

### DIFF
--- a/configmaster/management/handlers/config_backup.py
+++ b/configmaster/management/handlers/config_backup.py
@@ -128,11 +128,9 @@ class NetworkDeviceConfigBackupHandler(NetworkDeviceHandler):
         :attr:`configmaster.models.Device.last_checksum` field if necessary.
         """
 
-        checksum = self._get_config_checksum()
+        self.checksum = self._get_config_checksum()
 
-        if checksum != self.device.last_checksum:
-            self.device.last_checksum = checksum
-            self.device.save(update_fields=['last_checksum'])
+        if self.checksum != self.device.last_checksum:
             return False
         else:
             return True
@@ -248,6 +246,12 @@ class NetworkDeviceConfigBackupHandler(NetworkDeviceHandler):
                 raw_config = f.read()
             with codecs.open(temp_filename, 'w', encoding="utf8") as f:
                 f.write(raw_config)
+
+    def _return_success(self, message, *args):
+        if self.device.last_checksum != self.checksum:
+            self.device.last_checksum = self.checksum
+            self.device.save(update_fields=['last_checksum'])
+        super(NetworkDeviceConfigBackupHandler, self)._return_success(message, *args)
 
     def run(self, *args, **kwargs):
         """


### PR DESCRIPTION
The checksum was being saved before doing the backup. If a backup would
now fail, this failure would be masked by the wrong checksum.

Fixes #18