### PR TITLE
Fix fortigate config backup

### DIFF
--- a/configmaster/management/handlers/config_backup.py
+++ b/configmaster/management/handlers/config_backup.py
@@ -248,10 +248,13 @@ class NetworkDeviceConfigBackupHandler(NetworkDeviceHandler):
                 f.write(raw_config)
 
     def _return_success(self, message, *args):
-        if self.device.last_checksum != self.checksum:
-            self.device.last_checksum = self.checksum
-            self.device.save(update_fields=['last_checksum'])
-        super(NetworkDeviceConfigBackupHandler, self)._return_success(message, *args)
+        has_new_checksum = getattr(self, 'checksum', False)
+        if has_new_checksum and self.device.last_checksum != self.checksum:
+                self.device.last_checksum = self.checksum
+                self.device.save(update_fields=['last_checksum'])
+        return super(
+            NetworkDeviceConfigBackupHandler, self
+        )._return_success(message, *args)
 
     def run(self, *args, **kwargs):
         """

--- a/configmaster_project/tests/test_config_backup.py
+++ b/configmaster_project/tests/test_config_backup.py
@@ -66,6 +66,9 @@ def test_fortigate_config_backup(
         device_info['version'],
     )
 
+    report = device.get_latest_report_for_task(backup_task)
+    assert report.result_is_success()
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('device_info', config['junipers'])


### PR DESCRIPTION
Fixes two problems:
  * AttributeError if checksum was not set before.
  * `_return_success` did not return anything.

Also adapt the test so that the success status of the task gets checked.

Issue #18