### PR TITLE
fortigate: Disable pager for read_sysinfo

### DIFF
--- a/utils/remote/fortigate.py
+++ b/utils/remote/fortigate.py
@@ -117,7 +117,8 @@ class FortigateRemoteControl(common.NetworkDeviceRemoteControl):
             self.run_command("set admin-scp enable", True)
 
     def read_sysinfo(self):
-        output = self.run_command("get system status")
+        with self.ctx_term_setup():
+            output = self.run_command("get system status")
         match = RE_SYSINFO.match(output)
 
         if match:


### PR DESCRIPTION
Workaround for #15 to ensure that this code works everywhere. Concerns in https://github.com/leoluk/configmaster/issues/15#issuecomment-338473666 apply.

Needs to be tested with a real FortiGate