### PR TITLE
Force authentication for all endpoints

### DIFF
--- a/configmaster_project/settings.py
+++ b/configmaster_project/settings.py
@@ -144,6 +144,8 @@ USE_L10N = True
 
 USE_TZ = True
 
+LOGIN_URL = '/admin/login'
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
@@ -162,7 +164,10 @@ CONFIGMASTER_SECURE_GROUP_PLURAL = "secure-"
 
 CONFIGMASTER_NTP_MAX_DELTA = 5
 
-CONFIGMASTER_PW_CHANGE_API_KEY = None
+# API key for password change API (endpoint disabled if unspecified)
+CONFIGMASTER_PW_CHANGE_API_KEY = os.getenv('CONFIGMASTER_PW_CHANGE_API_KEY')
+# API key for device status API (endpoint disabled if unspecified)
+CONFIGMASTER_STATUS_API_KEY = os.getenv('CONFIGMASTER_STATUS_API_KEY')
 
 # External CMDB settings
 

--- a/openshift/configmaster.yaml
+++ b/openshift/configmaster.yaml
@@ -39,6 +39,11 @@ parameters:
   name: VOLUME_CAPACITY
   required: true
   value: 1Gi
+- displayName: API key for status and PW change APIs
+  from: '[a-zA-Z0-9]{16}'
+  generate: expression
+  name: CM_API_KEY
+
 objects:
 
 #------------------------------------------------- Django
@@ -59,6 +64,7 @@ objects:
     name: ${NAME}
   stringData:
     django-secret-key: ${DJANGO_SECRET_KEY}
+    cm-api-key: ${CM_API_KEY}
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -140,6 +146,16 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: django-secret-key
+                name: ${NAME}
+          - name: CONFIGMASTER_PW_CHANGE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: cm-api-key
+                name: ${NAME}
+          - name: CONFIGMASTER_STATUS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: cm-api-key
                 name: ${NAME}
           - name: DATABASE_NAME
             valueFrom:


### PR DESCRIPTION
...in order to account for deployment scenarios without reverse proxy or other security measures (and to make auditors happy).

This adds an API key for the existing device version and Nagios endpoints. As soon as we move to Django REST Framework, we can use their authentication mechanism which is a lot nicer.