### PR TITLE
Add Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,8 @@ pipeline {
     stage('Setup') {
       steps {
         timeout(unit: 'MINUTES', time: 10) {
-          sh '''oc process -f openshift/configmaster.yaml "GIT_REF=${BRANCH_NAME}" "NAME=configmaster-branch-${BRANCH_NAME}" -l "app=branch-${BRANCH_NAME}" | oc create -f -
-oc rollout status dc/configmaster-branch-jenkins'''
+          sh '''oc process -f openshift/configmaster.yaml "GIT_REF=${BRANCH_NAME}" "NAME=configmaster-build-${GIT_COMMIT:0:7}" -l "app=build-${GIT_COMMIT:0:7}" | oc create -f -
+oc rollout status dc/configmaster-build-${GIT_COMMIT:0:7}'''
         }
         
       }
@@ -13,14 +13,14 @@ oc rollout status dc/configmaster-branch-jenkins'''
     stage('Run tests') {
       steps {
         catchError() {
-          sh 'oc rsh "dc/configmaster-branch-${BRANCH_NAME}" scl enable python27 -- ./manage.py run junos-dev-vmx-16'
+          sh 'oc rsh "dc/configmaster-build-${GIT_COMMIT:0:7}" scl enable python27 -- ./manage.py run junos-dev-vmx-16'
         }
         
       }
     }
     stage('Teardown') {
       steps {
-        sh 'oc delete all,secret,pvc -l "app=branch-${BRANCH_NAME}"'
+        sh 'oc delete all,secret,pvc -l "app=build-${GIT_COMMIT:0:7}"'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+  agent any
+  stages {
+    stage('Setup') {
+      steps {
+        timeout(unit: 'MINUTES', time: 10) {
+          sh '''oc process -f openshift/configmaster.yaml "GIT_REF=${BRANCH_NAME}" "NAME=configmaster-branch-${BRANCH_NAME}" -l "app=branch-${BRANCH_NAME}" | oc create -f -
+oc rollout status dc/configmaster-branch-jenkins'''
+        }
+        
+      }
+    }
+    stage('Run tests') {
+      steps {
+        catchError() {
+          sh 'oc rsh "dc/configmaster-branch-${BRANCH_NAME}" scl enable python27 -- ./manage.py run junos-dev-vmx-16'
+        }
+        
+      }
+    }
+    stage('Teardown') {
+      steps {
+        sh 'oc delete all,secret,pvc -l "app=branch-${BRANCH_NAME}"'
+      }
+    }
+  }
+}

--- a/OpenShift.md
+++ b/OpenShift.md
@@ -18,7 +18,7 @@ Generate SSH key and upload it:
 
 Create application:
 
-    oc create -f openshift/configmaster.yaml | oc create -f
+    oc process -f openshift/configmaster.yaml | oc create -f -
 
 Tear down:
 

--- a/openshift/configmaster.yaml
+++ b/openshift/configmaster.yaml
@@ -113,7 +113,7 @@ objects:
           execNewPod:
             command:
               - fixtures/init_dev.sh
-            containerName: configmaster
+            containerName: ${NAME}
             volumes:
               - shared-data
           failurePolicy: Abort


### PR DESCRIPTION
(not running any of the actual tests yet, but it does a run for all devices in the fixtures)

Short summary:

* Jenkins itself runs in OpenShift and its service account has `edit` permissions to the parent project.
* The Jenkinsfile runs in an ephemeral pod and deploys the full ConfigMaster dev environment, including database, with a unique, per-branch name and app label (allowing for multiple concurrent builds in the same project).
* The Jenkins project has pre-configured SSH secrets and services pointing to the test devices.
* The tests are run within the dev environment, not the Jenkins agent pod.
* The deployment is deleted afterwards. If the Jenkins build fails outside the try/catch, manual cleanup is necessary and builds for that branch will fail.