### PR TITLE
fortigate: Use exec_command for read_sysinfo

### DIFF
--- a/utils/remote/fortigate.py
+++ b/utils/remote/fortigate.py
@@ -117,7 +117,7 @@ class FortigateRemoteControl(common.NetworkDeviceRemoteControl):
             self.run_command("set admin-scp enable", True)
 
     def read_sysinfo(self):
-        output = self.run_command("get system status")
+        output = self.exec_command("get system status")
         match = RE_SYSINFO.match(output)
 
         if match:


### PR DESCRIPTION
Fixes #15

Needs testing, I have no FortiGate.