### PR TITLE
Make tests more robust

### DIFF
--- a/configmaster_project/tests/conftest.py
+++ b/configmaster_project/tests/conftest.py
@@ -2,6 +2,8 @@ import os
 
 import yaml
 import pytest
+from sh import git
+
 from configmaster.models import (
     Credential,
     ConnectionSetting,
@@ -10,9 +12,7 @@ from configmaster.models import (
     Repository,
     Task,
 )
-
-DUMMY_LABEL = 'AA00'
-
+from utils import cleanup_repo
 
 config_path = os.path.join('configmaster_project', 'test_config.yaml')
 with open(config_path) as f:
@@ -44,13 +44,16 @@ def connection_setting():
     return connection_setting
 
 
+
+
 @pytest.fixture
 def repository():
     repo_path = config['repository']['path']
-
+    cleanup_repo(repo_path)
     repository = Repository(
         path=repo_path,
     )
+    repository.id = 1
     repository.save()
     return repository
 
@@ -119,3 +122,11 @@ def ntp_task():
     )
     ntp_task.save()
     return ntp_task
+
+@pytest.fixture
+def label(request):
+    """
+    Returns a dummy label containing the name of the test.
+    """
+    test_name = request.node.name
+    return 'label_for_' + test_name

--- a/configmaster_project/tests/test_config_backup.py
+++ b/configmaster_project/tests/test_config_backup.py
@@ -1,10 +1,12 @@
-import pytest
+import os
 
+import pytest
 from django.core.management import call_command
+from sh import git
 
 from configmaster.models import Device, Repository
 from .utils import get_last_commit_message, get_last_commit_id
-from conftest import config, DUMMY_LABEL
+from conftest import config
 
 
 def _check_new_commit(last_commit_id, repository_path, device):
@@ -12,12 +14,16 @@ def _check_new_commit(last_commit_id, repository_path, device):
     Verifies that there is a new commit with the expected commit message.
     """
     current_commit_id = get_last_commit_id(repository_path)
-    # There should be a new commit.
-    assert last_commit_id != current_commit_id
+    assert last_commit_id != current_commit_id, 'There should be a new commit.'
 
     commit_message = get_last_commit_message(repository_path)
+    if commit_message == 'Symlink updates':
+        os.chdir(repository_path)
+        git('checkout', 'HEAD~1')
+        commit_message = get_last_commit_message(repository_path)
+        git('checkout', 'master')
     expected_commit_message = (
-        '{group_name} config change on {label} ({hostname})'.format(
+        '{group_name} config for {label} added'.format(
             group_name=device.group.name,
             label=device.label,
             hostname=device.hostname,
@@ -35,9 +41,18 @@ def _check_config_backup(
     last_commit_id = get_last_commit_id(repository_path)
     call_command('run', device.label)
     device.refresh_from_db()
+    backup_task = device.device_type.tasks.first()
+    report = device.get_latest_report_for_task(backup_task)
+    assert report is not None
+    assert report.result_is_success(), \
+        'Report failed with output "{}" and long output "{}"'.format(
+            report.output,
+            report.long_output
+        )
+    assert report.output == 'Config backup successful (changes found)'
+    _check_new_commit(last_commit_id, repository_path, device)
     if expected_version is not None:
         assert device.version_info[:len(expected_version)] == expected_version
-    _check_new_commit(last_commit_id, repository_path, device)
 
 
 @pytest.mark.django_db
@@ -47,13 +62,14 @@ def test_fortigate_config_backup(
         device_group,
         backup_task,
         device_info,
+        label,
 ):
     device_type = device_type_fortigate
 
     hostname = device_info['hostname']
     device_type.tasks.add(backup_task)
     device = Device(
-        label=DUMMY_LABEL,
+        label=label,
         hostname=hostname,
         group=device_group,
         device_type=device_type,
@@ -66,9 +82,6 @@ def test_fortigate_config_backup(
         device_info['version'],
     )
 
-    report = device.get_latest_report_for_task(backup_task)
-    assert report.result_is_success()
-
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('device_info', config['junipers'])
@@ -77,11 +90,12 @@ def test_juniper_config_backup(
         device_group,
         backup_task,
         device_info,
+        label,
 ):
     device_type = device_type_juniper
     device_type.tasks.add(backup_task)
     device = Device(
-        label=DUMMY_LABEL,
+        label=label,
         hostname=device_info['hostname'],
         group=device_group,
         device_type=device_type,
@@ -102,11 +116,12 @@ def test_procurve_config_backup(
         device_group,
         backup_task,
         device_info,
+        label,
 ):
     device_type = device_type_procurve
     device_type.tasks.add(backup_task)
     device = Device(
-        label=DUMMY_LABEL,
+        label=label,
         hostname=device_info['hostname'],
         group=device_group,
         device_type=device_type,
@@ -127,6 +142,7 @@ def test_fortigate_no_backup_if_the_config_did_not_change(
         device_group,
         backup_task,
         device_info,
+        label,
 ):
     device_type = device_type_fortigate
 
@@ -135,7 +151,7 @@ def test_fortigate_no_backup_if_the_config_did_not_change(
     device_type.checksum_config_compare = True
     device_type.save()
     device = Device(
-        label=DUMMY_LABEL,
+        label=label,
         hostname=hostname,
         group=device_group,
         device_type=device_type,
@@ -162,6 +178,7 @@ def test_fortigate_backup_also_fails_on_repeated_runs(
         device_group,
         backup_task,
         device_info,
+        label,
 ):
     from configmaster.management.handlers.config_backup import NetworkDeviceConfigBackupHandler
 
@@ -177,7 +194,7 @@ def test_fortigate_backup_also_fails_on_repeated_runs(
     device_group.save()
     hostname = device_info['hostname']
     device = Device(
-        label=DUMMY_LABEL,
+        label=label,
         hostname=hostname,
         group=device_group,
         device_type=device_type,

--- a/configmaster_project/tests/test_config_compare.py
+++ b/configmaster_project/tests/test_config_compare.py
@@ -3,7 +3,7 @@ import pytest
 from django.core.management import call_command
 
 from configmaster.models import Task, DeviceType, Device
-from conftest import config, DUMMY_LABEL
+from conftest import config
 
 
 @pytest.mark.django_db
@@ -13,6 +13,7 @@ def test_juniper_get_version(
         connection_setting,
         device_group,
         juniper,
+        label,
 ):
     task = Task(
         name='Config Compare',
@@ -21,7 +22,6 @@ def test_juniper_get_version(
     task.save()
 
     hostname = juniper['hostname']
-    label = DUMMY_LABEL
     expected_version = juniper['version']
 
     device_type = DeviceType(

--- a/configmaster_project/tests/test_ntp.py
+++ b/configmaster_project/tests/test_ntp.py
@@ -3,7 +3,7 @@ from django.core.management import call_command
 from django.conf import settings
 
 from configmaster.models import Device, Report
-from conftest import config, DUMMY_LABEL
+from conftest import config
 
 
 def _check_ntp(device):
@@ -35,13 +35,14 @@ def test_ntp_juniper(
         ntp_task,
         device_info,
         device_group,
+        label,
 ):
     device_type = device_type_juniper
     hostname = device_info['hostname']
 
     device_type.tasks.add(ntp_task)
     device = Device(
-        label=DUMMY_LABEL,
+        label=label,
         hostname=hostname,
         group=device_group,
         device_type=device_type,
@@ -59,13 +60,14 @@ def test_ntp_fortigate(
         ntp_task,
         device_info,
         device_group,
+        label,
 ):
     device_type = device_type_fortigate
     hostname = device_info['hostname']
 
     device_type.tasks.add(ntp_task)
     device = Device(
-        label=DUMMY_LABEL,
+        label=label,
         hostname=hostname,
         group=device_group,
         device_type=device_type,
@@ -83,13 +85,14 @@ def test_ntp_procurve(
         ntp_task,
         device_info,
         device_group,
+        label,
 ):
     device_type = device_type_procurve
     hostname = device_info['hostname']
 
     device_type.tasks.add(ntp_task)
     device = Device(
-        label=DUMMY_LABEL,
+        label=label,
         hostname=hostname,
         group=device_group,
         device_type=device_type,

--- a/configmaster_project/tests/utils.py
+++ b/configmaster_project/tests/utils.py
@@ -1,6 +1,6 @@
 import os
 
-from sh import git
+from sh import git, ErrorReturnCode
 
 
 def get_last_commit_message(repository_path):
@@ -11,3 +11,16 @@ def get_last_commit_message(repository_path):
 def get_last_commit_id(repository_path):
     os.chdir(repository_path)
     return str(git('log', '-1', '--format=%H', _tty_out=False)).strip()
+
+
+def cleanup_repo(repository_path):
+    """
+    Generates a commit which deletes everything.
+    """
+    os.chdir(repository_path)
+    try:
+        git('rm', '-rf', '.')
+    except ErrorReturnCode:
+        pass
+    else:
+        git('commit', '-m', 'Clean up everything')


### PR DESCRIPTION
Some improvements to make the tests independent of each other and easier
to debug.

* Clean up the repository before each test run.
* Use device labels which are unique for each test.
* Verify the task's output before the commit message, so that it is
  easier to see what the problem was.