### PR TITLE
Fix /api/device_status endpoint

### DIFF
--- a/configmaster/views.py
+++ b/configmaster/views.py
@@ -118,7 +118,7 @@ class DeviceStatusAPIView(View):
 
         if report and report.long_output:
             url = reverse('admin:%s_%s_change' %(
-                report._meta.app_label, report._meta.module_name),
+                report._meta.app_label, report._meta.model_name),
                           args=[report.id] )
             url = request.build_absolute_uri(url)
 

--- a/configmaster_project/tests/test_views.py
+++ b/configmaster_project/tests/test_views.py
@@ -1,0 +1,29 @@
+from configmaster.models import Device, Task, Report
+
+
+def test_device_status_api_view(admin_client, device_group):
+    device_label = 'AA00'
+    device = Device(label=device_label, group=device_group)
+    device.save()
+
+    task_id = 5
+    task = Task(id=task_id)
+    task.save()
+
+    report = Report(
+        device=device,
+        task=task,
+        result=Report.RESULT_FAILURE,
+        output='error',
+        long_output='There was an error.'
+    )
+    report.save()
+
+    url = '/api/device_status?task={}&device={}'.format(
+        str(task_id),
+        device_label,
+    )
+    response = admin_client.get(url)
+
+    assert response.status_code == 200
+    assert 'There was an error.' in response.content


### PR DESCRIPTION
Change deprecated _meta.module_name to _meta.model_name

https://docs.djangoproject.com/en/1.11/releases/1.8/#features-removed-in-1-8