### PR TITLE
Make device locking mechanism more robust

### DIFF
--- a/configmaster/management/commands/run.py
+++ b/configmaster/management/commands/run.py
@@ -276,20 +276,21 @@ class Command(BaseCommand):
                     device.lock.acquire()
                     self.stdout.write("Running tasks...")
 
-                    retries = 0
-                    while True:
-                        report, result = self.run_task(device, task)
-                        if ((result == Report.RESULT_FAILURE) and
-                                (retries < settings.CONFIGMASTER_RETRIES) and
-                                (not any(x in report.output for x in
-                                         DO_NOT_RETRY))):
-                            retries += 1
-                            self.stdout.write('Retrying... (%d/%d)' % (
-                                retries, settings.CONFIGMASTER_RETRIES))
-                        else:
-                            break
-
-                    device.lock.release()
+                    try:
+                        retries = 0
+                        while True:
+                            report, result = self.run_task(device, task)
+                            if ((result == Report.RESULT_FAILURE) and
+                                    (retries < settings.CONFIGMASTER_RETRIES) and
+                                    (not any(x in report.output for x in
+                                             DO_NOT_RETRY))):
+                                retries += 1
+                                self.stdout.write('Retrying... (%d/%d)' % (
+                                    retries, settings.CONFIGMASTER_RETRIES))
+                            else:
+                                break
+                    finally:
+                        device.lock.release()
 
 
         # Call run_complete methods of all invoked task handlers

--- a/utils/locking.py
+++ b/utils/locking.py
@@ -14,7 +14,6 @@ class FileLock(object):
             "configmaster-lock-"+name.lstrip('/').replace("/", "-")
         )
         self.f = open(filename, 'w')
-        os.chmod(filename, 0o666)
         self.acquired = False
 
     def acquire(self, non_blocking=False):

--- a/utils/locking.py
+++ b/utils/locking.py
@@ -14,6 +14,7 @@ class FileLock(object):
             "configmaster-lock-"+name.lstrip('/').replace("/", "-")
         )
         self.f = open(filename, 'w')
+        os.chmod(filename, 0o666)
         self.acquired = False
 
     def acquire(self, non_blocking=False):


### PR DESCRIPTION
Sometimes admins would run configmaster as root users which would lead
to lock files being inaccessible for subsequent runs of the normal
configmaster user. This is now avoided by explicitly making the
lockfiles readable and writable by anyone.

Also added a try-finally block to make sure that locks are always
released, as not doing so could lead to blocking and timeout if several
tasks would be run for one device with one task failing.

CON-41