### PR TITLE
Replace Jenkins with GitHub Actions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,0 +1,38 @@
+name: Python application
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Set up Python 2.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 2.7
+        
+    - name: Install dependencies
+      run: |
+        sudo apt install -y libmysqlclient-dev libldap2-dev libsasl2-dev
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        
+    - name: Run no-op run test with dev fixtures
+      run: |
+        export DJANGO_DEBUG=1
+        export DJANGO_SECRET_KEY=secret
+        ./manage.py migrate
+        ./fixtures/init_dev.sh
+        ./manage.py run


### PR DESCRIPTION
I no longer have access to the lab environment the Jenkins tests used, so we cannot test with real devices until I set up a new lab env on the Continum dev server.