### PR TITLE
clear_old_reports: Use timezone-aware datetime

### DIFF
--- a/configmaster/management/commands/clear_old_reports.py
+++ b/configmaster/management/commands/clear_old_reports.py
@@ -7,6 +7,7 @@
 import datetime
 
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 from configmaster.models import Report
 
@@ -25,5 +26,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         Report.objects.filter(
-            date__lte=datetime.datetime.today() - datetime.timedelta(
+            date__lte=timezone.now() - datetime.timedelta(
                 days=7)).delete()


### PR DESCRIPTION
`datetime.datetime.today` returns a naive datetime which causes a
warning on every run of this command (RuntimeWarning: DateTimeField
Report.date received a naive datetime). Use `django.utils.timezone.now`
instead which uses the configured timezone.